### PR TITLE
fix: cli - build and release

### DIFF
--- a/.github/workflows/cli-build-and-release.yaml
+++ b/.github/workflows/cli-build-and-release.yaml
@@ -43,7 +43,7 @@ jobs:
       with:
         tag_name: ${{ steps.version_bump.outputs.new_tag }}
         release_name: CLI Release ${{ steps.version_bump.outputs.new_tag }}
-        body: ${{ steps.tag_version.outputs.changelog }}
+        body: ${{ steps.version_bump.outputs.changelog }}
     outputs:
       tag: ${{ steps.version_bump.outputs.new_tag }}
       release_upload_url: ${{ steps.create_release.outputs.upload_url }}
@@ -54,7 +54,7 @@ jobs:
     strategy:
       matrix:
         goarch: [amd64]
-        goos: [linux, darwin, windows]
+        goos: [linux, darwin]
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-go@v2


### PR DESCRIPTION
* removed windows as a CLI target
* fixed a bad path in the yaml which was preventing release messages being added